### PR TITLE
Update to latest packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,8 +10,8 @@
     "license": "LICENSE.MD",
     "devDependencies": {
         "@types/node": "^25.0.2",
-        "assemblyscript": "^0.28.9",
-        "prettier": "^3.7.4"
+        "prettier": "^3.7.4",
+        "@btc-vision/assemblyscript": "^0.29.2"
     },
     "keywords": [
         "bitcoin",
@@ -26,10 +26,9 @@
     "homepage": "https://opnet.org",
     "type": "module",
     "dependencies": {
-        "@assemblyscript/loader": "^0.28.9",
-        "@btc-vision/as-bignum": "^0.0.7",
-        "@btc-vision/btc-runtime": "^1.10.12",
-        "@btc-vision/opnet-transform": "^0.2.1",
+        "@btc-vision/as-bignum": "0.1.2",
+        "@btc-vision/btc-runtime": "^1.11.0-rc.7",
+        "@btc-vision/opnet-transform": "^1.2.0",
         "gulplog": "^2.2.0",
         "ts-node": "^10.9.2"
     }

--- a/src/contracts/AdministeredOP20.ts
+++ b/src/contracts/AdministeredOP20.ts
@@ -26,10 +26,9 @@ export abstract class AdministeredOP20 extends OP20 {
         this._admin = new StoredAddress(Blockchain.nextPointer);
     }
 
-    public onUpdate(calldata: Calldata): void {
-        this.onlyDeployer(Blockchain.tx.sender);
+    public override onUpdate(_calldata: Calldata): void {
+        super.onUpdate(_calldata);
     }
-
 
     public onDeployment(_calldata: Calldata): void {
         this.instantiate(

--- a/src/contracts/AdministeredOP20.ts
+++ b/src/contracts/AdministeredOP20.ts
@@ -26,6 +26,11 @@ export abstract class AdministeredOP20 extends OP20 {
         this._admin = new StoredAddress(Blockchain.nextPointer);
     }
 
+    public onUpdate(calldata: Calldata): void {
+        this.onlyDeployer(Blockchain.tx.sender);
+    }
+
+
     public onDeployment(_calldata: Calldata): void {
         this.instantiate(
             new OP20InitParameters(this.__maxSupply, this.__decimals, this.__name, this.__symbol),
@@ -39,6 +44,7 @@ export abstract class AdministeredOP20 extends OP20 {
      *
      * @param _calldata Empty calldata.
      */
+    @view()
     @method()
     @returns('address')
     public admin(_calldata: Calldata): BytesWriter {

--- a/src/contracts/Moto.ts
+++ b/src/contracts/Moto.ts
@@ -16,6 +16,11 @@ export class Moto extends AdministeredOP20 {
         super(u256.fromString('1000000000000000000000000000'), 18, 'Motoswap', 'MOTO');
     }
 
+    public onUpdate(calldata: Calldata): void {
+        this.onlyDeployer(Blockchain.tx.sender);
+    }
+
+
     /**
      * Mints tokens to the specified addresses.
      *

--- a/src/contracts/Moto.ts
+++ b/src/contracts/Moto.ts
@@ -16,8 +16,8 @@ export class Moto extends AdministeredOP20 {
         super(u256.fromString('1000000000000000000000000000'), 18, 'Motoswap', 'MOTO');
     }
 
-    public onUpdate(calldata: Calldata): void {
-        this.onlyDeployer(Blockchain.tx.sender);
+    public override onUpdate(_calldata: Calldata): void {
+        super.onUpdate(_calldata);
     }
 
 


### PR DESCRIPTION
- Bump opnet-related packages to latest.
- Add `@view()` decorator to readonly functions.
- Add no-op `onUpdate` to all contracts.
- Replace assemblyscript with @btc-vision/assemblyscript